### PR TITLE
Not all shared libs were being imported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,6 +196,7 @@ install:
       rm conan.deb
     else
       # sudo pip install conan
+      brew update
       brew install conan
     fi
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -13,10 +13,10 @@ ZMQ:shared=False
 [imports]
 bin, protoc* -> ./
 bin, *.dylib -> ./
-bin, *.so -> ./
+bin, *.so* -> ./
 bin, *.dll -> ./
 lib, *.dylib -> ./
-lib, *.so -> ./
+lib, *.so* -> ./
 lib, *.dll -> ./
 
 # bin, *.dll -> ./bin


### PR DESCRIPTION
as they have a so.9 pattern. With that, you can execute binary as:

``` bash
$ LD_LIBRARY_PATH=./ ./protoc 
```
